### PR TITLE
Fix sizes to work with resfet

### DIFF
--- a/modules/configs/luna_hotfire.json
+++ b/modules/configs/luna_hotfire.json
@@ -136,19 +136,10 @@
             }
         },
         "commands": {
-            "ACK_VALUE": 1,
-            "PAYLOAD": 2,
-            "TEXT": 3,
-            "UNSET_VALVE": 4,
-            "SET_VALVE": 5,
-            "UNSET_IGNITION": 6,
-            "SET_IGNITION": 7,
-            "NORM_IGNITE": 8,
-    
-            "LC_MAIN_SEND": 9,
-            "LC1_SEND": 10,
-            "LC2_SEND": 11,
-            "LC3_SEND": 12,
+            "LC_MAIN_SEND": 0,
+            "LC1_SEND": 1,
+            "LC2_SEND": 2,
+            "LC3_SEND": 3,
             "PT_FEED_SEND": 13,
             "PT_INJE_SEND": 14,
             "PT_COMB_SEND": 15,

--- a/modules/packets.js
+++ b/modules/packets.js
@@ -100,8 +100,8 @@ module.exports = {
         if (using_mocked) {
             // Header format: type (1 byte), padding (7 bytes),
             // number (4 bytes), padding (4 bytes)
-            expected_size = 16;
-            number_offset = 8;
+            expected_size = 4;
+            number_offset = 2;
         } else {
             // Header format: type (1 byte), padding (3 bytes),
             // number (4 bytes)
@@ -113,7 +113,7 @@ module.exports = {
             return [];
         }
         let type = msg.readUInt8(0);
-        let number = msg.readUInt32LE(number_offset);
+        let number = msg.readUInt16LE(number_offset);
         return [type, number];
     },
 
@@ -135,7 +135,8 @@ module.exports = {
         // Payload format: data (2 bytes), padding (6 bytes),
         // timestamp (8 bytes)
         let msg_size = rinfo.size;
-        let header_size = using_mocked ? 16 : 8;
+        let header_size = using_mocked ? 4 : 8;
+	console.log("Received packet of length " + msg_size);
         if (msg_size < header_size + 16) {
             console.log("[ERROR] Packet is too short to read any payloads");
             return [];


### PR DESCRIPTION
Progress PR to discuss integration with resfet.

So far I've changed the struct sizes and send codes to work with resfet on the data branch. The size of structs should be platform independent in this version because we use standard-size data types instead of 'int' and 'long'.